### PR TITLE
Add law library to list of commissions

### DIFF
--- a/sf_gov_commissions.csv
+++ b/sf_gov_commissions.csv
@@ -31,6 +31,7 @@
 "Human Rights Commission","Charter Sec. 4.107"
 "Human Services Commission","Charter Sec. 4.111"
 "Juvenile Probation Commission","Charter Sec. 7.102"
+"Law Library Board of Trustees","Charter Sec. 8.103"
 "Library Commission","Charter Sec. 8.102"
 "Municipal Transportation Agency Board of Directors","Charter Sec. 8A.102"
 "Our Children, Our Families Council","Charter Sec. 16.127-1; Administrative Code Sec. 102.1"


### PR DESCRIPTION
#22 adds the law library to the list of departments, so this PR adds their board to the list of commissions as per https://github.com/m-atoms/sf-gov-entities/pull/22#issuecomment-2423561007